### PR TITLE
Fix an issue with buffers ending with code.

### DIFF
--- a/outorg.el
+++ b/outorg.el
@@ -1251,7 +1251,7 @@ block."
 next line and return `t'. Otherwise, leaves point alone and
 returns `nil'."
   (cond
-   ((looking-at "^[[:space:]]*$") (forward-line))
+   ((looking-at "[[:space:]]*$") (forward-line))
    ((outorg-comment-on-line-p) (forward-line))
    (t nil)))
 
@@ -1374,7 +1374,8 @@ space."
 		    ;; loop until C is at EOB
 		    ((< pt-B-pos pt-C-pos)
 		     (goto-char outorg-pt-C-marker))
-		    (t "This should not happen")))))
+		    (t "This should not happen"))))
+            (when (< pt-C-pos pt-B-pos) (goto-char (point-max))))
 	  ;; reset markers
 	  (move-marker outorg-pt-B-marker nil)
 	  (move-marker outorg-pt-C-marker nil)


### PR DESCRIPTION
The parser could get into an infinite loop for want of handling possible arrangements of markers at the end of the buffer. 

Namely, the beginning-of-code marker (B) ends up at point-max, while the end-of-code marker (C) is moved to the end of a code block on the last non-empty line of the file (1- (point-max)), taking point with it.

This fixes one snag I've run into a few times. Another is if a buffer ends with a headline, I get an error regarding markers. Haven't tracked that down yet.