### PR TITLE
Specify minimum Emacs version

### DIFF
--- a/outorg.el
+++ b/outorg.el
@@ -3,6 +3,7 @@
 ;; Author: Thorsten Jolitz <tjolitz AT gmail DOT com>
 ;; Version: 2.0
 ;; URL: https://github.com/tj64/outorg
+;; Package-Requires: ((emacs "24.4"))
 
 ;;;; MetaData
 ;;   :PROPERTIES:


### PR DESCRIPTION
Some org function requires version which is bundled in 24.4 or higher versions.